### PR TITLE
Change admin enqueue function name

### DIFF
--- a/class-links.php
+++ b/class-links.php
@@ -37,17 +37,17 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Links' ) && class_exists( '\\Dekode\\Hoga
 			$this->template          = __DIR__ . '/assets/template.php';
 			$this->inner_wrapper_tag = 'nav';
 
-			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 
 			parent::__construct();
 		}
 
 		/**
-		 * Enqueue module assets
+		 * Enqueue module admin assets
 		 *
 		 * @return void
 		 */
-		public function enqueue_assets() {
+		public function enqueue_admin_assets() {
 			$_version = defined( 'SCRIPT_DEBUG' ) && true === SCRIPT_DEBUG ? time() : false;
 			wp_enqueue_style( 'links-admin-style', plugins_url( '/assets/admin-style.css', __FILE__ ), [], $_version );
 		}


### PR DESCRIPTION
After https://github.com/DekodeInteraktiv/hogan-core/pull/32 was merged the `enqueue_assets` function will automagic enqueue assets frontend. Change admin assets function name so admin assets not get enqueued frontend.